### PR TITLE
e2e: replace IMAGE_FORMAT with RELEASE_IMAGE_LATEST

### DIFF
--- a/test/e2e/operator_test.go
+++ b/test/e2e/operator_test.go
@@ -33,8 +33,8 @@ func TestMain(m *testing.M) {
 		os.Exit(1)
 	}
 
-	if os.Getenv("IMAGE_FORMAT") == "" {
-		klog.Errorf("IMAGE_FORMAT environment variable not set")
+	if os.Getenv("RELEASE_IMAGE_LATEST") == "" {
+		klog.Errorf("RELEASE_IMAGE_LATEST environment variable not set")
 		os.Exit(1)
 	}
 
@@ -104,8 +104,8 @@ func TestMain(m *testing.M) {
 				required := resourceread.ReadDeploymentV1OrDie(objBytes)
 				// override the operator image with the one built in the CI
 
-				// E.g. IMAGE_FORMAT=registry.build03.ci.openshift.org/ci-op-52fj47p4/stable:${component}
-				registry := strings.Split(os.Getenv("IMAGE_FORMAT"), "/")[0]
+				// E.g. RELEASE_IMAGE_LATEST=registry.build01.ci.openshift.org/ci-op-fy99k61r/release@sha256:0d05e600baea6df9dcd453d3b72c925b8672685cd94f0615c1089af4aa39f215
+				registry := strings.Split(os.Getenv("RELEASE_IMAGE_LATEST"), "/")[0]
 
 				required.Spec.Template.Spec.Containers[0].Image = registry + "/" + os.Getenv("NAMESPACE") + "/pipeline:run-once-duration-override-operator"
 				// OPERAND_IMAGE env


### PR DESCRIPTION
IMAGE_FORMAT is deprecating and set to an empty string in some cases