### PR TITLE
CSV: remove comma from the CR example

### DIFF
--- a/manifests/runoncedurationoverride-operator.clusterserviceversion.yaml
+++ b/manifests/runoncedurationoverride-operator.clusterserviceversion.yaml
@@ -15,7 +15,7 @@ metadata:
           "spec": {
             "runOnceDurationOverride": {
               "spec": {
-                "activeDeadlineSeconds": 3600,
+                "activeDeadlineSeconds": 3600
               }
             }
           }


### PR DESCRIPTION
```
time="2023-02-04T15:52:45Z" level=error msg="Error: Value invalid character at 257\n [\n  {\n    \"apiVersion\": \"operator.openshift.io/v1\",\n    \"kind\": \"RunOnceDurationOverride\",\n    \"metadata\": {\n      \"name\": \"cluster\"\n    },\n    \"spec\": {\n      \"runOnceDurationOverride\": {\n        \"spec\": {\n          \"activeDeadlineSeconds\": 3600,\n        }<--(see the invalid character): invalid example"
```