### PR TITLE
Rename APIGroup

### DIFF
--- a/deploy/03_clusterrole.yaml
+++ b/deploy/03_clusterrole.yaml
@@ -142,7 +142,7 @@ rules:
 
   # to grant power to the operand to allow anonymous access to the admission server
   - apiGroups:
-      - admission.apps.openshift.io
+      - admission.runoncedurationoverride.openshift.io
     resources:
       - runoncedurationoverrides
     verbs:

--- a/manifests/runoncedurationoverride-operator.clusterserviceversion.yaml
+++ b/manifests/runoncedurationoverride-operator.clusterserviceversion.yaml
@@ -201,7 +201,7 @@ spec:
             - hostnetwork-v2
         # to grant power to the operand to allow anonymous access to the admission server
         - apiGroups:
-            - admission.apps.openshift.io
+            - admission.runoncedurationoverride.openshift.io
           resources:
             - runoncedurationoverrides
           verbs:

--- a/pkg/asset/asset.go
+++ b/pkg/asset/asset.go
@@ -14,7 +14,7 @@ func New(context runtime.OperandContext) *Asset {
 		ServiceAccountName:             context.WebhookName(),
 		OperandImage:                   context.OperandImage(),
 		OperandVersion:                 context.OperandVersion(),
-		AdmissionAPIGroup:              "admission.apps.openshift.io",
+		AdmissionAPIGroup:              "admission.runoncedurationoverride.openshift.io",
 		AdmissionAPIVersion:            "v1",
 		AdmissionAPIResource:           "runoncedurationoverrides",
 		OwnerLabelKey:                  "operator.apps.openshift.io/runoncedurationoverride",

--- a/test/e2e/bindata/assets/03_clusterrole.yaml
+++ b/test/e2e/bindata/assets/03_clusterrole.yaml
@@ -143,7 +143,7 @@ rules:
 
   # to grant power to the operand to allow anonymous access to the admission server
   - apiGroups:
-      - admission.apps.openshift.io
+      - admission.runoncedurationoverride.openshift.io
     resources:
       - runoncedurationoverrides
     verbs:

--- a/test/e2e/operator_test.go
+++ b/test/e2e/operator_test.go
@@ -250,7 +250,7 @@ func TestMain(m *testing.M) {
 }
 
 func TestRunOnceDurationOverriding(t *testing.T) {
-	// runoncedurationoverrides.admission.apps.openshift.io/enabled: "true"
+	// runoncedurationoverrides.admission.runoncedurationoverride.openshift.io/enabled: "true"
 	ctx, cancelFnc := context.WithCancel(context.TODO())
 	defer cancelFnc()
 
@@ -260,7 +260,7 @@ func TestRunOnceDurationOverriding(t *testing.T) {
 		ObjectMeta: metav1.ObjectMeta{
 			Name: "e2e-" + strings.ToLower(t.Name()),
 			Labels: map[string]string{
-				"runoncedurationoverrides.admission.apps.openshift.io/enabled": "true",
+				"runoncedurationoverrides.admission.runoncedurationoverride.openshift.io/enabled": "true",
 			},
 		},
 	}


### PR DESCRIPTION
This PR renames APIGroup from `admission.apps.openshift.io` to `admission.runoncedurationoverride.openshift.io`.

This PR is blocked by https://github.com/openshift/run-once-duration-override/pull/11