### PR TITLE
Prefix OPERAND_IMAGE env with RELATED_IMAGE_ so OSBS can replace the registry during bundle image build

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ This operator manages OpenShift `RunOnceDurationOverride` Admission Webhook Serv
 
 1. Update the image spec under `.spec.template.spec.containers[0].image` field in the `deploy/07_deployment.yaml` Deployment to point to the newly built image
 
-1. Update the `OPERAND_IMAGE` env value under `.spec.template.spec.containers[0].envs` field in the `deploy/07_deployment.yaml` to point to the admission webhook image
+1. Update the `RELATED_IMAGE_OPERAND_IMAGE` env value under `.spec.template.spec.containers[0].envs` field in the `deploy/07_deployment.yaml` to point to the admission webhook image
 
 1. Update the `.spec.runOnceDurationOverride.spec.activeDeadlineSeconds` under `deploy/08_cr.yaml` as needed
 
@@ -61,7 +61,7 @@ This process refers to building the operator in a way that it can be installed l
 
  1. Update the `.spec.install.spec.deployments[0].spec.template.spec.containers[0].image` field in the RODOO CSV under `manifests/runoncedurationoverride-operator.clusterserviceversion.yaml` to point to the newly built image.
 
- 1. Update the `OPERAND_IMAGE` env value under `.spec.install.spec.deployments[0].spec.template.spec.containers[0].envs` field in the RODOO CSV under `manifests/runoncedurationoverride-operator.clusterserviceversion.yaml` to point to the admission webhook image.
+ 1. Update the `RELATED_IMAGE_OPERAND_IMAGE` env value under `.spec.install.spec.deployments[0].spec.template.spec.containers[0].envs` field in the RODOO CSV under `manifests/runoncedurationoverride-operator.clusterserviceversion.yaml` to point to the admission webhook image.
 
 
  1. build and push the metadata image to a registry (e.g. https://quay.io):

--- a/deploy/07_deployment.yaml
+++ b/deploy/07_deployment.yaml
@@ -40,7 +40,7 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: metadata.namespace
-            - name: OPERAND_IMAGE
+            - name: RELATED_IMAGE_OPERAND_IMAGE
               value: registry.ci.openshift.org/ocp/4.13:run-once-duration-override-webhook
             - name: OPERAND_VERSION
               value: 1.0.0

--- a/manifests/runoncedurationoverride-operator.clusterserviceversion.yaml
+++ b/manifests/runoncedurationoverride-operator.clusterserviceversion.yaml
@@ -292,7 +292,7 @@ spec:
                       valueFrom:
                         fieldRef:
                           fieldPath: metadata.namespace
-                    - name: OPERAND_IMAGE
+                    - name: RELATED_IMAGE_OPERAND_IMAGE
                       value: registry-proxy.engineering.redhat.com/rh-osbs/run-once-duration-override-rhel-8:latest
                     - name: OPERAND_VERSION
                       value: 1.0.0

--- a/pkg/cmd/operator/start.go
+++ b/pkg/cmd/operator/start.go
@@ -3,18 +3,19 @@ package operator
 import (
 	"context"
 	"fmt"
+	"os"
+
 	"github.com/spf13/cobra"
 	"k8s.io/apiserver/pkg/server"
 	"k8s.io/client-go/tools/clientcmd"
 	"k8s.io/klog"
-	"os"
 
 	"github.com/openshift/run-once-duration-override-operator/pkg/operator"
 )
 
 const (
 	OperatorName          = "runoncedurationoverride"
-	OperandImageEnvName   = "OPERAND_IMAGE"
+	OperandImageEnvName   = "RELATED_IMAGE_OPERAND_IMAGE"
 	OperandVersionEnvName = "OPERAND_VERSION"
 )
 

--- a/test/e2e/bindata/assets/07_deployment.yaml
+++ b/test/e2e/bindata/assets/07_deployment.yaml
@@ -40,7 +40,7 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: metadata.namespace
-            - name: OPERAND_IMAGE
+            - name: RELATED_IMAGE_OPERAND_IMAGE
               value: RUNONCEDURATIONOVERRIDE_OPERAND_IMAGE
             - name: OPERAND_VERSION
               value: 1.0.0

--- a/test/e2e/operator_test.go
+++ b/test/e2e/operator_test.go
@@ -108,9 +108,9 @@ func TestMain(m *testing.M) {
 				registry := strings.Split(os.Getenv("RELEASE_IMAGE_LATEST"), "/")[0]
 
 				required.Spec.Template.Spec.Containers[0].Image = registry + "/" + os.Getenv("NAMESPACE") + "/pipeline:run-once-duration-override-operator"
-				// OPERAND_IMAGE env
+				// RELATED_IMAGE_OPERAND_IMAGE env
 				for i, env := range required.Spec.Template.Spec.Containers[0].Env {
-					if env.Name == "OPERAND_IMAGE" {
+					if env.Name == "RELATED_IMAGE_OPERAND_IMAGE" {
 						required.Spec.Template.Spec.Containers[0].Env[i].Value = "registry.ci.openshift.org/ocp/4.13:run-once-duration-override-webhook"
 						break
 					}


### PR DESCRIPTION
See https://osbs.readthedocs.io/en/latest/users.html#pullspec-locations for details about pullspec locations.