### PR TITLE
Sync with main

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,13 @@ This operator manages OpenShift `RunOnceDurationOverride` Admission Webhook Serv
 
 `RunOnceDurationOverride` Admission Webhook Server is located at [run-once-duration-override](https://github.com/openshift/run-once-duration-override).
 
+## Releases
+
+| rodoo version | ocp version |
+| ------------- | ----------- |
+| 1.0.0         | 4.13, 4.14  |
+| 1.0.1         | 4.13, 4.14  |
+
 ## Deploy the Operator
 
 ### Quick Development

--- a/manifests/runoncedurationoverride-operator.clusterserviceversion.yaml
+++ b/manifests/runoncedurationoverride-operator.clusterserviceversion.yaml
@@ -32,6 +32,7 @@ metadata:
     categories: OpenShift Optional
     operators.openshift.io/valid-subscription: '["OpenShift Container Platform", "OpenShift Platform Plus"]'
 spec:
+  replaces: runoncedurationoverrideoperator.v1.0.0
   customresourcedefinitions:
     owned:
     - displayName: Run Once Duration Override


### PR DESCRIPTION
Keeping the release-4.14 in sync with master:HEAD before we start rebasing to k8s 1.28. After 1.0.1 is out release-4.14 will no longer accept any changes unless decided otherwise.