### PR TITLE
Operator deployment: set an emptyDir /tmp

### DIFF
--- a/Dockerfile.metadata
+++ b/Dockerfile.metadata
@@ -1,8 +1,8 @@
-FROM registry.ci.openshift.org/ocp/builder:rhel-8-golang-1.20-openshift-4.14 AS builder
+FROM registry.ci.openshift.org/ocp/builder:rhel-9-golang-1.21-openshift-4.16 AS builder
 WORKDIR /go/src/github.com/openshift/run-once-duration-override-operator
 COPY . .
 
-FROM registry.ci.openshift.org/ocp/builder:rhel-8-base-openshift-4.14
+FROM registry.ci.openshift.org/ocp/builder:rhel-9-base-openshift-4.16
 COPY --from=builder /go/src/github.com/openshift/run-once-duration-override-operator/manifests /manifests
 COPY --from=builder /go/src/github.com/openshift/run-once-duration-override-operator/metadata /metadata
 

--- a/Dockerfile.rhel7
+++ b/Dockerfile.rhel7
@@ -1,10 +1,10 @@
-FROM registry.ci.openshift.org/ocp/builder:rhel-8-golang-1.20-openshift-4.14 AS builder
+FROM registry.ci.openshift.org/ocp/builder:rhel-9-golang-1.21-openshift-4.16 AS builder
 WORKDIR /go/src/github.com/openshift/run-once-duration-override-operator
 COPY . .
 
 RUN make build
 
-FROM registry.ci.openshift.org/ocp/builder:rhel-8-base-openshift-4.14
+FROM registry.ci.openshift.org/ocp/builder:rhel-9-base-openshift-4.16
 COPY --from=builder /go/src/github.com/openshift/run-once-duration-override-operator/run-once-duration-override-operator /usr/bin/
 # Upstream bundle and index images does not support versioning so
 # we need to copy a specific version under /manifests layout directly

--- a/deploy/07_deployment.yaml
+++ b/deploy/07_deployment.yaml
@@ -21,6 +21,9 @@ spec:
         runAsNonRoot: true
         seccompProfile:
           type: RuntimeDefault
+      volumes:
+      - name: tmp
+        emptyDir: {}
       containers:
         - name: run-once-duration-override-operator
           securityContext:
@@ -66,3 +69,6 @@ spec:
             capabilities:
               drop:
               - ALL
+          volumeMounts:
+          - name: tmp
+            mountPath: "/tmp"

--- a/manifests/runoncedurationoverride-operator.clusterserviceversion.yaml
+++ b/manifests/runoncedurationoverride-operator.clusterserviceversion.yaml
@@ -319,4 +319,10 @@ spec:
                       path: /healthz
                       port: 8080
                     initialDelaySeconds: 5
+                  volumeMounts:
+                  - name: tmp
+                    mountPath: "/tmp"
               serviceAccountName: run-once-duration-override-operator
+              volumes:
+              - name: tmp
+                emptyDir: {}

--- a/test/e2e/bindata/assets/07_deployment.yaml
+++ b/test/e2e/bindata/assets/07_deployment.yaml
@@ -17,6 +17,9 @@ spec:
         runoncedurationoverride.operator: "true"
     spec:
       serviceAccountName: run-once-duration-override-operator
+      volumes:
+      - name: tmp
+        emptyDir: {}
       securityContext:
         runAsNonRoot: true
         seccompProfile:
@@ -60,3 +63,6 @@ spec:
             capabilities:
               drop:
               - ALL
+          volumeMounts:
+          - name: tmp
+            mountPath: "/tmp"


### PR DESCRIPTION
readOnlyRootFilesystem SecurityContext is enabled by default in Deployment object definition. As a result, /tmp is read-only and not writable.