### PR TITLE
Prepare 1.1.2 release

### DIFF
--- a/manifests/runoncedurationoverride-operator.clusterserviceversion.yaml
+++ b/manifests/runoncedurationoverride-operator.clusterserviceversion.yaml
@@ -1,7 +1,7 @@
 apiVersion: operators.coreos.com/v1alpha1
 kind: ClusterServiceVersion
 metadata:
-  name: runoncedurationoverrideoperator.v1.1.1
+  name: runoncedurationoverrideoperator.v1.1.2
   namespace: run-once-duration-override-operator
   annotations:
     alm-examples: |
@@ -34,7 +34,7 @@ metadata:
     features.operators.openshift.io/cnf: "false"
     features.operators.openshift.io/cni: "false"
     features.operators.openshift.io/csi: "false"
-    olm.skipRange: ">=1.0.0 <1.1.1"
+    olm.skipRange: ">=1.0.0 <1.1.2"
     description: An operator to manage the OpenShift RunOnceDurationOverride Mutating Admission Webhook Server
     repository: https://github.com/openshift/run-once-duration-override-operator
     support: Red Hat, Inc.
@@ -42,7 +42,16 @@ metadata:
     categories: OpenShift Optional
     operators.openshift.io/valid-subscription: '["OpenShift Container Platform", "OpenShift Platform Plus"]'
 spec:
-  replaces: runoncedurationoverrideoperator.v1.1.0
+  replaces: runoncedurationoverrideoperator.v1.0.0
+  skips:
+  - runoncedurationoverrideoperator.v1.0.1
+  - runoncedurationoverrideoperator.v1.0.2
+  - runoncedurationoverrideoperator.v1.0.3
+  - runoncedurationoverrideoperator.v1.0.4
+  - runoncedurationoverrideoperator.v1.0.5
+  - runoncedurationoverrideoperator.v1.0.6
+  - runoncedurationoverrideoperator.v1.1.0
+  - runoncedurationoverrideoperator.v1.1.1
   customresourcedefinitions:
     owned:
     - displayName: Run Once Duration Override
@@ -57,7 +66,7 @@ spec:
   provider:
     name: Red Hat, Inc.
   maturity: beta
-  version: 1.1.1
+  version: 1.1.2
   links:
   - name: Source Code
     url: https://github.com/openshift/run-once-duration-override
@@ -69,7 +78,7 @@ spec:
   minKubeVersion: 1.28.0
   labels:
     olm-owner-enterprise-app: run-once-duration-override-operator
-    olm-status-descriptors: run-once-duration-override-operator.v1.1.1
+    olm-status-descriptors: run-once-duration-override-operator.v1.1.2
   installModes:
   - supported: true
     type: OwnNamespace
@@ -307,7 +316,7 @@ spec:
                     - name: RELATED_IMAGE_OPERAND_IMAGE
                       value: registry-proxy.engineering.redhat.com/rh-osbs/run-once-duration-override-rhel-8:latest
                     - name: OPERAND_VERSION
-                      value: 1.1.1
+                      value: 1.1.2
                   ports:
                     - containerPort: 8080
                   readinessProbe:


### PR DESCRIPTION
The first time we use a buffer for skipped releases to maintain a reachable to-be-added-patch-releases in the future so `opm index add` is happy to accept the patch releases for all existing index bundle images.