### PR TITLE
no-jira: Set suggested-namespace and related annotations

### DIFF
--- a/manifests/runoncedurationoverride-operator.clusterserviceversion.yaml
+++ b/manifests/runoncedurationoverride-operator.clusterserviceversion.yaml
@@ -41,6 +41,9 @@ metadata:
     capabilities: Basic Install
     categories: OpenShift Optional
     operators.openshift.io/valid-subscription: '["OpenShift Container Platform", "OpenShift Platform Plus"]'
+    operatorframework.io/cluster-monitoring: "true"
+    operatorframework.io/suggested-namespace: "openshift-run-once-duration-override-operator"
+    console.openshift.io/operator-monitoring-default: "true"
 spec:
   replaces: runoncedurationoverrideoperator.v1.0.0
   skips:


### PR DESCRIPTION
Add a few annotations:
- operatorframework.io/cluster-monitoring: "true"
- operatorframework.io/suggested-namespace: "openshift-run-once-duration-override-operator"
- console.openshift.io/operator-monitoring-default: "true" to simplify the deployment via OCP console.