### PR TITLE
no-jira: chore(deps): update operand and operator images to the latest

### DIFF
--- a/bundle.Dockerfile
+++ b/bundle.Dockerfile
@@ -5,8 +5,8 @@ COPY . .
 RUN mkdir licenses
 COPY ./LICENSE licenses/.
 
-ARG OPERATOR_IMAGE=registry.stage.redhat.io/run-once-duration-override-operator/run-once-duration-override-rhel9-operator@sha256:cdcb345c6dec76c7c5afe074db5c5edb28d5244020e602c7a51d3df0169d7595
-ARG OPERAND_IMAGE=registry.stage.redhat.io/run-once-duration-override-operator/run-once-duration-override-rhel9@sha256:5465ee7480f7cdc6bdb7575e9b74c67ad471763029f4878b46377b7667a8f390
+ARG OPERATOR_IMAGE=registry.stage.redhat.io/run-once-duration-override-operator/run-once-duration-override-rhel9-operator@sha256:c2f7cf2dd2b5135b9390d2895128fbe84bb2ed05f1b36f1cd393ea06f1ce3e03
+ARG OPERAND_IMAGE=registry.stage.redhat.io/run-once-duration-override-operator/run-once-duration-override-rhel9@sha256:a556bbbf320b041784c5d7ae4e00027e21d50c3c5395be8b2c134b106810df19
 ARG REPLACED_OPERATOR_IMG=registry-proxy.engineering.redhat.com/rh-osbs/run-once-duration-override-rhel9-operator:latest
 ARG REPLACED_OPERAND_IMG=registry-proxy.engineering.redhat.com/rh-osbs/run-once-duration-override-rhel-9:latest
 


### PR DESCRIPTION
SSIA

Taking over https://github.com/openshift/run-once-duration-override-operator/pull/312 and https://github.com/openshift/run-once-duration-override-operator/pull/315.