### PR TITLE
feat(.tekton): add DAST integration test pipeline for RODOO 4.21

### DIFF
--- a/.tekton/integration-tests/README.md
+++ b/.tekton/integration-tests/README.md
@@ -1,0 +1,140 @@
+# RODOO DAST Integration Tests on Konflux
+
+## Overview
+
+This directory contains the DAST (Dynamic Application Security Testing) pipeline for the
+Run Once Duration Override Operator (RODOO) on Konflux. The pipeline runs automatically when
+the RODOO bundle image is built, provisioning an ephemeral OCP cluster and executing security scans.
+
+## Pipeline
+
+**File:** `pipelines/run-once-duration-override-operator-dast-pipeline-4-21.yaml`
+
+### What it does
+
+1. **Provisions** an ephemeral OCP 4.21 cluster via EaaS (Environment as a Service)
+2. **Installs** the RODOO operator from the Konflux-built SNAPSHOT bundle using `operator-sdk run bundle`
+3. **Applies** an enriched `RunOnceDurationOverride` CR with all spec fields populated to
+   maximize test coverage
+4. **Runs oobtkube** (out-of-box testing for Kubernetes) as a Job on the ephemeral cluster to detect
+   blind command injection vulnerabilities in the operator's CR reconciliation logic
+5. **Runs Trivy** misconfiguration scan against deployed RODOO workloads
+6. **Uploads results** to GCS (`secaut-bucket`) and surfaces findings in the Konflux UI
+   via `TEST_OUTPUT` / `SCAN_OUTPUT` task results
+
+### Architecture
+
+```
+Konflux Build Pipeline
+        |
+        v  (SNAPSHOT with bundle image)
+IntegrationTestScenario (konflux-release-data)
+        |
+        v  (git resolver)
+DAST Pipeline (this repo)
+        |
+        +-- parse-metadata
+        +-- eaas-provision-space (ownerKind: PipelineRun)
+        +-- provision-cluster (OCP 4.21 + imageContentSources)
+        +-- install-rodoo-operator (operator-sdk run bundle from SNAPSHOT)
+        +-- dast-test
+              +-- get-kubeconfig
+              +-- orchestrate-dast (oc: ns, RBAC, ConfigMap, RapiDAST Job)
+              +-- post-process (TEST_OUTPUT + SCAN_OUTPUT)
+```
+
+oobtkube runs **on the ephemeral cluster** as a Kubernetes Job (not as a Tekton step).
+This ensures the oobtkube TCP listener and the RODOO operator share the same network,
+allowing the callback mechanism to work correctly.
+
+### Container images used
+
+| Step | Image | Why |
+|------|-------|-----|
+| install-operator, orchestrate-dast, post-process | `quay.io/konflux-ci/konflux-test:latest` | Has `oc`, `kubectl`, `jq`, `/utils.sh` |
+| RapiDAST Job (on ephemeral cluster) | `quay.io/redhatproductsecurity/rapidast:latest` | Has `rapidast.py`, `oobtkube.py` (via `python3.12`), `trivy`, `kubectl` |
+| results-fetcher | `registry.access.redhat.com/ubi9/ubi:latest` | Pod to mount PVC for `oc cp` (needs `tar`) |
+
+## Prerequisites
+
+### GCS Secret
+
+A Google Cloud Storage service account key must be provisioned in the `rodoo-workloads-tenant`
+namespace on the Konflux cluster:
+
+- **Secret name:** `rapidast-sa-rodoo-key`
+- **Key:** `sa-key` (JSON service account credentials)
+- **Bucket:** `secaut-bucket`
+
+Request access via the SecAut Bucket Access Repository (same process as KDO).
+
+### IntegrationTestScenario
+
+The ITS resource `run-once-duration-override-operator-4-21-dast` must exist in
+`konflux-release-data` under the `rodoo-workloads-tenant`. It is configured with:
+
+- `test.appstudio.openshift.io/optional: "true"` label (non-blocking)
+- Context filter: `component_run-once-duration-override-operator-bundle-4-21` (triggers on bundle builds)
+- Param: `rodoo_version: "4.21"` (for GCS path tagging)
+
+### imageContentSources
+
+The ephemeral cluster is configured with image content source mirrors so that
+`operator-sdk run bundle` can pull images built by Konflux:
+
+| Registry source | Konflux mirror |
+|----------------|----------------|
+| `registry.redhat.io/run-once-duration-override-operator/run-once-duration-override-rhel9-operator` | `quay.io/redhat-user-workloads/rodoo-workloads-tenant/run-once-duration-override-operator-4-21` |
+| `registry.redhat.io/run-once-duration-override-operator/run-once-duration-override-rhel-9` | `quay.io/redhat-user-workloads/rodoo-workloads-tenant/run-once-duration-override-4-21` |
+| `registry.redhat.io/run-once-duration-override-operator/run-once-duration-override-operator-bundle` | `quay.io/redhat-user-workloads/rodoo-workloads-tenant/run-once-duration-override-operator-bundle-4-21` |
+
+## Interpreting Results
+
+### Konflux UI
+
+- **TEST_OUTPUT**: Shows `SUCCESS` if the pipeline completed. Check `SCAN_OUTPUT` for details.
+- **SCAN_OUTPUT**: JSON with vulnerability counts by severity (critical/high/medium/low).
+
+### GCS Archive
+
+Results are uploaded to `gs://secaut-bucket/rodoo/<version>/oobtkube/` by RapiDAST's
+native `google.cloud.storage` integration. Contains the full SARIF report.
+
+### oobtkube Findings
+
+oobtkube detects blind command injection by injecting `curl <pod-ip>:<port>` payloads
+into CR string fields. The pod IP is injected via the Kubernetes downward API (`POD_IP` env var).
+If the operator executes any injected command, oobtkube's listener receives the callback
+and reports a finding. Any finding indicates a critical vulnerability.
+
+The scanner is configured as `generic_oobtkube` in RapiDAST (using the `generic_<name>` pattern)
+and uses `python3.12` (the default `python3` in the RapiDAST image lacks `pyyaml`).
+
+### Trivy Findings
+
+Trivy scans deployed RODOO workloads for Kubernetes misconfigurations (HIGH/CRITICAL severity).
+Results are saved as JSON in the shared volume.
+
+## Enriched CR
+
+The test uses an enriched `RunOnceDurationOverride` CR (cluster-scoped) with all available fields:
+
+- **managementState**: Set to `Managed` (pattern-validated, not an injection target)
+- **runOnceDurationOverride.spec.activeDeadlineSeconds**: Set to `3600` (integer, not an injection target)
+- **runOnceDurationOverride.apiVersion** and **kind**: Populated string fields for oobtkube coverage
+
+RODOO has a minimal CR spec compared to KDO or OSSO. The primary oobtkube value comes from
+confirming no injection is possible through the limited string fields, while Trivy provides
+misconfiguration coverage for deployed workloads (operator deployment, webhook, DaemonSet).
+
+## Known Limitations
+
+- **Limited oobtkube attack surface**: RODOO's CR has very few string fields. Most spec values
+  are integers or pattern-validated. The primary DAST value comes from Trivy misconfiguration scanning.
+- **Trivy namespace flag**: Trivy k8s uses `--include-namespaces` (not `--namespace`).
+- **`python3.12` required for oobtkube**: The RapiDAST image's default `python3` (3.9) lacks
+  `pyyaml`. The config must use `python3.12` for the oobtkube inline command.
+- **`hostname` unavailable in RapiDAST container**: Pod IP must be injected via the Kubernetes
+  downward API (`POD_IP` env var) instead of `$(hostname -i)`.
+- **Non-hermetic**: Integration test pipelines on Konflux are not subject to hermetic build
+  constraints. Runtime downloads and `:latest` tags are acceptable per Konflux docs.

--- a/.tekton/integration-tests/configs/rapidast-job.yaml
+++ b/.tekton/integration-tests/configs/rapidast-job.yaml
@@ -1,0 +1,55 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: rapidast-rodoo-oobtkube
+  namespace: rapidast-rodoo
+spec:
+  backoffLimit: 0
+  template:
+    spec:
+      serviceAccountName: privileged-sa
+      containers:
+        - name: rapidast
+          image: quay.io/redhatproductsecurity/rapidast:latest
+          imagePullPolicy: Always
+          command: ["/bin/bash", "-c"]
+          args:
+            - |
+              rapidast.py --log-level debug --config /opt/rapidast/config/rapidastconfig.yaml
+              RESULT=$?
+              cp /opt/rapidast/results/*.sarif /opt/rapidast/pvc-results/ 2>/dev/null || true
+              cp /opt/rapidast/results/*.json /opt/rapidast/pvc-results/ 2>/dev/null || true
+              exit $RESULT
+          env:
+            - name: POD_IP
+              valueFrom:
+                fieldRef:
+                  fieldPath: status.podIP
+          securityContext:
+            privileged: true
+          resources:
+            requests:
+              cpu: 500m
+              memory: 1Gi
+            limits:
+              cpu: 2000m
+              memory: 4Gi
+          volumeMounts:
+            - name: config
+              mountPath: /opt/rapidast/config
+            - name: results
+              mountPath: /opt/rapidast/pvc-results
+            - name: gcs-key
+              mountPath: /etc/gcs
+              readOnly: true
+      volumes:
+        - name: config
+          configMap:
+            name: rapidast-rodoo-config
+        - name: results
+          persistentVolumeClaim:
+            claimName: rapidast-pvc
+        - name: gcs-key
+          secret:
+            secretName: rapidast-sa-rodoo-key
+      restartPolicy: Never

--- a/.tekton/integration-tests/configs/rapidastconfig.yaml
+++ b/.tekton/integration-tests/configs/rapidastconfig.yaml
@@ -1,0 +1,25 @@
+config:
+  configVersion: 6
+  googleCloudStorage:
+    keyFile: "/etc/gcs/sa-key"
+    bucketName: "secaut-bucket"
+    directory: "rodoo/${RODOO_VERSION}"
+
+application:
+  shortName: "rodoo"
+  url: "https://kubernetes.default.svc"
+
+general:
+  container:
+    type: "none"
+
+scanners:
+  generic_oobtkube:
+    results: "/opt/rapidast/results/oobtkube-results.sarif"
+    inline: |
+      python3.12 oobtkube.py --find-all --log-level debug -d 300 -p 6000 -i ${POD_IP} -f /opt/rapidast/config/rodoo-cr.yaml -o /opt/rapidast/results/oobtkube-results.sarif
+
+  generic_trivy:
+    results: "/opt/rapidast/results/trivy-results.json"
+    inline: |
+      trivy k8s --include-namespaces openshift-run-once-duration-override-operator --scanners=misconfig --severity HIGH,CRITICAL --report all --format json --output /opt/rapidast/results/trivy-results.json --skip-check-update

--- a/.tekton/integration-tests/configs/rodoo-cr.yaml
+++ b/.tekton/integration-tests/configs/rodoo-cr.yaml
@@ -1,0 +1,11 @@
+apiVersion: operator.openshift.io/v1
+kind: RunOnceDurationOverride
+metadata:
+  name: cluster
+spec:
+  managementState: Managed
+  runOnceDurationOverride:
+    apiVersion: operator.openshift.io/v1
+    kind: RunOnceDurationOverride
+    spec:
+      activeDeadlineSeconds: 3600

--- a/.tekton/integration-tests/pipelines/run-once-duration-override-operator-dast-pipeline-4-21.yaml
+++ b/.tekton/integration-tests/pipelines/run-once-duration-override-operator-dast-pipeline-4-21.yaml
@@ -1,0 +1,446 @@
+---
+apiVersion: tekton.dev/v1beta1
+kind: Pipeline
+metadata:
+  name: run-once-duration-override-operator-dast-pipeline
+spec:
+  description: |
+    DAST pipeline for Run Once Duration Override Operator (RODOO) on Konflux.
+    Provisions an ephemeral OCP 4.21 cluster, installs RODOO from SNAPSHOT bundle,
+    runs oobtkube (blind command injection testing via RapiDAST) as a Job on the
+    ephemeral cluster, and Trivy for misconfiguration scanning. Results are uploaded
+    to GCS and surfaced in Konflux UI via TEST_OUTPUT/SCAN_OUTPUT.
+  params:
+    - name: SNAPSHOT
+      description: "The JSON string representing the snapshot of the application under test."
+      default: '{"components": [{"name":"test-app", "containerImage": "quay.io/example/repo:latest"}]}'
+      type: string
+    - name: rodoo_version
+      description: "RODOO product version used to tag RapiDAST scan results in GCS"
+      type: string
+    - name: config_git_revision
+      description: "Git branch/revision used to fetch config files (rapidastconfig.yaml, rodoo-cr.yaml, rapidast-job.yaml). Set to a PR branch for pre-merge testing."
+      default: "main"
+      type: string
+  tasks:
+    # ──────────────────────────────────────────────────────────────────────────
+    # Task 1: parse-metadata
+    # ──────────────────────────────────────────────────────────────────────────
+    - name: parse-metadata
+      timeout: "5m"
+      taskRef:
+        resolver: git
+        params:
+          - name: url
+            value: https://github.com/konflux-ci/integration-examples
+          - name: revision
+            value: main
+          - name: pathInRepo
+            value: tasks/test_metadata.yaml
+      params:
+        - name: SNAPSHOT
+          value: $(params.SNAPSHOT)
+
+    # ──────────────────────────────────────────────────────────────────────────
+    # Task 2: eaas-provision-space
+    # ──────────────────────────────────────────────────────────────────────────
+    - name: eaas-provision-space
+      timeout: "5m"
+      runAfter:
+        - parse-metadata
+      when:
+        - input: $(tasks.parse-metadata.results.test-event-type)
+          operator: in
+          values: ["push", "Push", "PUSH", "incoming", "Incoming", "INCOMING"]
+      taskRef:
+        resolver: git
+        params:
+          - name: url
+            value: https://github.com/konflux-ci/build-definitions.git
+          - name: revision
+            value: main
+          - name: pathInRepo
+            value: task/eaas-provision-space/0.1/eaas-provision-space.yaml
+      params:
+        - name: ownerKind
+          value: PipelineRun
+        - name: ownerName
+          value: $(context.pipelineRun.name)
+        - name: ownerUid
+          value: $(context.pipelineRun.uid)
+
+    # ──────────────────────────────────────────────────────────────────────────
+    # Task 3: provision-cluster (OCP 4.21 + imageContentSources for RODOO)
+    # ──────────────────────────────────────────────────────────────────────────
+    - name: provision-cluster
+      timeout: "35m"
+      runAfter:
+        - eaas-provision-space
+      when:
+        - input: $(tasks.parse-metadata.results.test-event-type)
+          operator: in
+          values: ["push", "Push", "PUSH", "incoming", "Incoming", "INCOMING"]
+      taskSpec:
+        results:
+          - name: clusterName
+            value: "$(steps.create-cluster.results.clusterName)"
+        steps:
+          - name: get-supported-versions
+            ref:
+              resolver: git
+              params:
+                - name: url
+                  value: https://github.com/konflux-ci/build-definitions.git
+                - name: revision
+                  value: main
+                - name: pathInRepo
+                  value: stepactions/eaas-get-supported-ephemeral-cluster-versions/0.1/eaas-get-supported-ephemeral-cluster-versions.yaml
+            params:
+              - name: eaasSpaceSecretRef
+                value: $(tasks.eaas-provision-space.results.secretRef)
+          - name: pick-version
+            ref:
+              resolver: git
+              params:
+                - name: url
+                  value: https://github.com/konflux-ci/build-definitions.git
+                - name: revision
+                  value: main
+                - name: pathInRepo
+                  value: stepactions/eaas-get-latest-openshift-version-by-prefix/0.1/eaas-get-latest-openshift-version-by-prefix.yaml
+            params:
+              - name: prefix
+                value: "4.20."
+          - name: create-cluster
+            ref:
+              resolver: git
+              params:
+                - name: url
+                  value: https://github.com/konflux-ci/build-definitions.git
+                - name: revision
+                  value: main
+                - name: pathInRepo
+                  value: stepactions/eaas-create-ephemeral-cluster-hypershift-aws/0.1/eaas-create-ephemeral-cluster-hypershift-aws.yaml
+            params:
+              - name: eaasSpaceSecretRef
+                value: $(tasks.eaas-provision-space.results.secretRef)
+              - name: version
+                value: "$(steps.pick-version.results.version)"
+              - name: instanceType
+                value: "m5.xlarge"
+              - name: timeout
+                value: "30m"
+              - name: imageContentSources
+                value: |
+                  - source: registry.redhat.io/run-once-duration-override-operator/run-once-duration-override-rhel9-operator
+                    mirrors:
+                      - quay.io/redhat-user-workloads/rodoo-workloads-tenant/run-once-duration-override-operator-4-21
+                  - source: registry.redhat.io/run-once-duration-override-operator/run-once-duration-override-rhel-9
+                    mirrors:
+                      - quay.io/redhat-user-workloads/rodoo-workloads-tenant/run-once-duration-override-4-21
+                  - source: registry.redhat.io/run-once-duration-override-operator/run-once-duration-override-operator-bundle
+                    mirrors:
+                      - quay.io/redhat-user-workloads/rodoo-workloads-tenant/run-once-duration-override-operator-bundle-4-21
+
+    # ──────────────────────────────────────────────────────────────────────────
+    # Task 4: install-rodoo-operator (from SNAPSHOT bundle via operator-sdk)
+    # ──────────────────────────────────────────────────────────────────────────
+    - name: install-rodoo-operator
+      timeout: "5m"
+      runAfter:
+        - provision-cluster
+      when:
+        - input: $(tasks.parse-metadata.results.test-event-type)
+          operator: in
+          values: ["push", "Push", "PUSH", "incoming", "Incoming", "INCOMING"]
+      params:
+        - name: SNAPSHOT
+          value: $(params.SNAPSHOT)
+      taskSpec:
+        params:
+          - name: SNAPSHOT
+        volumes:
+          - name: credentials
+            emptyDir: {}
+        steps:
+          - name: get-kubeconfig
+            ref:
+              resolver: git
+              params:
+                - name: url
+                  value: https://github.com/konflux-ci/build-definitions.git
+                - name: revision
+                  value: main
+                - name: pathInRepo
+                  value: stepactions/eaas-get-ephemeral-cluster-credentials/0.1/eaas-get-ephemeral-cluster-credentials.yaml
+            params:
+              - name: eaasSpaceSecretRef
+                value: $(tasks.eaas-provision-space.results.secretRef)
+              - name: clusterName
+                value: "$(tasks.provision-cluster.results.clusterName)"
+              - name: credentials
+                value: credentials
+          - name: install-operator
+            image: quay.io/konflux-ci/konflux-test:latest
+            env:
+              - name: SNAPSHOT
+                value: $(params.SNAPSHOT)
+              - name: KONFLUX_COMPONENT_NAME
+                valueFrom:
+                  fieldRef:
+                    fieldPath: metadata.labels['appstudio.openshift.io/component']
+              - name: KUBECONFIG
+                value: "/credentials/$(steps.get-kubeconfig.results.kubeconfig)"
+            volumeMounts:
+              - name: credentials
+                mountPath: /credentials
+            script: |
+              #!/bin/bash
+              set -euxo pipefail
+
+              export ARCH=$(case $(uname -m) in x86_64) echo -n amd64 ;; aarch64) echo -n arm64 ;; *) echo -n $(uname -m) ;; esac)
+              export OPERATOR_SDK_DL_URL=https://github.com/operator-framework/operator-sdk/releases/download/v1.42.2
+              curl -LO ${OPERATOR_SDK_DL_URL}/operator-sdk_linux_${ARCH}
+              chmod +x operator-sdk_linux_${ARCH}
+              mv operator-sdk_linux_${ARCH} /usr/local/bin/operator-sdk
+
+              echo "KONFLUX_COMPONENT_NAME: ${KONFLUX_COMPONENT_NAME}"
+              BUNDLE_IMAGE="$(jq -r --arg component_name "$KONFLUX_COMPONENT_NAME" \
+                '.components[] | select(.name == $component_name) | .containerImage' <<< "$SNAPSHOT")"
+              echo "BUNDLE_IMAGE: ${BUNDLE_IMAGE}"
+
+              oc create namespace openshift-run-once-duration-override-operator || true
+
+              operator-sdk run bundle --timeout=10m \
+                --namespace openshift-run-once-duration-override-operator \
+                "$BUNDLE_IMAGE" --verbose
+
+              oc wait --for condition=Available \
+                -n openshift-run-once-duration-override-operator \
+                deployment/run-once-duration-override-operator \
+                --timeout=120s
+
+    # ──────────────────────────────────────────────────────────────────────────
+    # Task 5: dast-test (oobtkube Job + Trivy + post-process)
+    # ──────────────────────────────────────────────────────────────────────────
+    - name: dast-test
+      timeout: "10m"
+      description: DAST testing with RapiDAST oobtkube and Trivy misconfiguration scan
+      runAfter:
+        - install-rodoo-operator
+      when:
+        - input: $(tasks.parse-metadata.results.test-event-type)
+          operator: in
+          values: ["push", "Push", "PUSH", "incoming", "Incoming", "INCOMING"]
+      params:
+        - name: SNAPSHOT
+          value: $(params.SNAPSHOT)
+        - name: rodoo_version
+          value: $(params.rodoo_version)
+        - name: config_git_revision
+          value: $(params.config_git_revision)
+      taskSpec:
+        params:
+          - name: SNAPSHOT
+          - name: rodoo_version
+            type: string
+          - name: config_git_revision
+            type: string
+        results:
+          - name: TEST_OUTPUT
+            description: Tekton task test output.
+          - name: SCAN_OUTPUT
+            description: DAST scan result.
+        volumes:
+          - name: credentials
+            emptyDir: {}
+          - name: gcs-key
+            secret:
+              secretName: rapidast-sa-rodoo-key
+          - name: shared
+            emptyDir: {}
+        steps:
+          - name: get-kubeconfig
+            ref:
+              resolver: git
+              params:
+                - name: url
+                  value: https://github.com/konflux-ci/build-definitions.git
+                - name: revision
+                  value: main
+                - name: pathInRepo
+                  value: stepactions/eaas-get-ephemeral-cluster-credentials/0.1/eaas-get-ephemeral-cluster-credentials.yaml
+            params:
+              - name: eaasSpaceSecretRef
+                value: $(tasks.eaas-provision-space.results.secretRef)
+              - name: clusterName
+                value: "$(tasks.provision-cluster.results.clusterName)"
+              - name: credentials
+                value: credentials
+
+          - name: orchestrate-dast
+            image: quay.io/konflux-ci/konflux-test:latest
+            env:
+              - name: KUBECONFIG
+                value: "/credentials/$(steps.get-kubeconfig.results.kubeconfig)"
+              - name: RODOO_VERSION
+                value: "$(params.rodoo_version)"
+              - name: CONFIG_GIT_REVISION
+                value: "$(params.config_git_revision)"
+            volumeMounts:
+              - name: credentials
+                mountPath: /credentials
+              - name: gcs-key
+                mountPath: /etc/gcs
+                readOnly: true
+              - name: shared
+                mountPath: /shared
+            script: |
+              #!/bin/bash
+              set -euxo pipefail
+              trap 'echo "DAST orchestration failed"; exit 1' ERR
+
+              # --- 1. Create namespace and RBAC on ephemeral cluster ---
+              oc create namespace rapidast-rodoo
+              oc create sa privileged-sa -n rapidast-rodoo
+              oc create clusterrolebinding rapidast-privileged \
+                --clusterrole=cluster-admin --serviceaccount=rapidast-rodoo:privileged-sa
+
+              # --- 2. Propagate GCS secret to ephemeral cluster ---
+              oc create secret generic rapidast-sa-rodoo-key \
+                --from-file=sa-key=/etc/gcs/sa-key \
+                --namespace=rapidast-rodoo \
+                --dry-run=client -o yaml | oc apply -f -
+
+              # --- 3. Fetch config files from repo ---
+              REPO_RAW="https://raw.githubusercontent.com/openshift/run-once-duration-override-operator/${CONFIG_GIT_REVISION}"
+              CONFIG_DIR=".tekton/integration-tests/configs"
+              curl -sfL "${REPO_RAW}/${CONFIG_DIR}/rapidastconfig.yaml" > /tmp/rapidastconfig.yaml
+              curl -sfL "${REPO_RAW}/${CONFIG_DIR}/rodoo-cr.yaml" > /tmp/rodoo-cr.yaml
+
+              # Expand ${RODOO_VERSION} in the RapiDAST config
+              export RODOO_VERSION
+              sed "s/\${RODOO_VERSION}/${RODOO_VERSION}/g" /tmp/rapidastconfig.yaml > /tmp/rapidastconfig-resolved.yaml
+
+              # --- 4. Create PVC for results on ephemeral cluster ---
+              cat <<'PVCEOF' | oc apply -f -
+              apiVersion: v1
+              kind: PersistentVolumeClaim
+              metadata:
+                name: rapidast-pvc
+                namespace: rapidast-rodoo
+              spec:
+                accessModes:
+                  - ReadWriteOnce
+                resources:
+                  requests:
+                    storage: 1Gi
+              PVCEOF
+
+              # --- 5. Create RapiDAST ConfigMap from fetched config files ---
+              oc create configmap rapidast-rodoo-config \
+                --from-file=rapidastconfig.yaml=/tmp/rapidastconfig-resolved.yaml \
+                --from-file=rodoo-cr.yaml=/tmp/rodoo-cr.yaml \
+                --namespace=rapidast-rodoo
+
+              # --- 6. Apply enriched CR on ephemeral cluster (for operator to reconcile) ---
+              oc apply -f /tmp/rodoo-cr.yaml
+
+              # Wait for operator to reconcile the CR
+              sleep 15
+              oc wait --for condition=Available \
+                -n openshift-run-once-duration-override-operator \
+                deployment/run-once-duration-override-operator \
+                --timeout=120s
+
+              # --- 7. Create RapiDAST Job on ephemeral cluster ---
+              curl -sfL "${REPO_RAW}/${CONFIG_DIR}/rapidast-job.yaml" > /tmp/rapidast-job.yaml
+              oc apply -f /tmp/rapidast-job.yaml
+
+              # --- 8. Wait for Job to terminate (complete or fail) ---
+              oc wait --for=condition=complete job/rapidast-rodoo-oobtkube \
+                -n rapidast-rodoo --timeout=600s 2>/dev/null \
+                || oc wait --for=condition=failed job/rapidast-rodoo-oobtkube \
+                -n rapidast-rodoo --timeout=30s 2>/dev/null \
+                || echo "Job still running after timeout"
+
+              # --- 9. Capture Job logs ---
+              oc logs job/rapidast-rodoo-oobtkube -n rapidast-rodoo > /shared/rapidast-rodoo-log.txt 2>&1 || true
+
+              # --- 10. Retrieve SARIF from PVC via helper pod ---
+              cat <<'CPEOF' | oc apply -f -
+              apiVersion: v1
+              kind: Pod
+              metadata:
+                name: results-fetcher
+                namespace: rapidast-rodoo
+              spec:
+                containers:
+                  - name: fetcher
+                    image: registry.access.redhat.com/ubi9/ubi:latest
+                    command: ["sleep", "300"]
+                    volumeMounts:
+                      - name: results
+                        mountPath: /results
+                volumes:
+                  - name: results
+                    persistentVolumeClaim:
+                      claimName: rapidast-pvc
+                restartPolicy: Never
+              CPEOF
+              oc wait --for=condition=Ready pod/results-fetcher -n rapidast-rodoo --timeout=60s
+              oc cp rapidast-rodoo/results-fetcher:/results/oobtkube-results.sarif /shared/oobtkube-results.sarif || true
+              oc cp rapidast-rodoo/results-fetcher:/results/trivy-results.json /shared/trivy-results.json || true
+
+              echo "DAST orchestration complete. Results in /shared/"
+
+          - name: post-process
+            image: quay.io/konflux-ci/konflux-test:latest
+            volumeMounts:
+              - name: shared
+                mountPath: /shared
+            script: |
+              #!/bin/bash
+              source /utils.sh
+              trap 'handle_error $(results.TEST_OUTPUT.path)' EXIT
+
+              scan_result='{"vulnerabilities":{"critical":0,"high":0,"medium":0,"low":0,"unknown":0}}'
+
+              # --- Parse oobtkube SARIF results ---
+              sarif_file=/shared/oobtkube-results.sarif
+              if [ -s "$sarif_file" ]; then
+                result=$(jq -rce '{
+                  vulnerabilities:{
+                    critical: ([.runs[0].results[]? | select(.level == "error")] | length),
+                    high: ([.runs[0].results[]? | select(.level == "warning")] | length),
+                    medium: ([.runs[0].results[]? | select(.level == "note")] | length),
+                    low: ([.runs[0].results[]? | select(.level == "none" or .level == null or .level == "")] | length),
+                    unknown: ([.runs[0].results[]? | select(.level != "error" and .level != "warning" and .level != "note" and .level != "none" and .level != null and .level != "")] | length)
+                  }}' "$sarif_file")
+                scan_result=$(jq -s -rce '.[0].vulnerabilities.critical += .[1].vulnerabilities.critical |
+                  .[0].vulnerabilities.high += .[1].vulnerabilities.high |
+                  .[0].vulnerabilities.medium += .[1].vulnerabilities.medium |
+                  .[0]' <<<"$scan_result $result")
+              fi
+
+              # --- Parse Trivy JSON results ---
+              trivy_file=/shared/trivy-results.json
+              if [ -s "$trivy_file" ]; then
+                trivy_result=$(jq -rce '{
+                  vulnerabilities:{
+                    critical: ([.Resources[]?.Results[]?.Misconfigurations[]? | select(.Severity == "CRITICAL")] | length),
+                    high: ([.Resources[]?.Results[]?.Misconfigurations[]? | select(.Severity == "HIGH")] | length),
+                    medium: 0,
+                    low: 0,
+                    unknown: 0
+                  }}' "$trivy_file")
+                scan_result=$(jq -s -rce '.[0].vulnerabilities.critical += .[1].vulnerabilities.critical |
+                  .[0].vulnerabilities.high += .[1].vulnerabilities.high |
+                  .[0]' <<<"$scan_result $trivy_result")
+              fi
+
+              echo "$scan_result" | tee "$(results.SCAN_OUTPUT.path)"
+
+              note="Task $(context.task.name) completed: Refer to SCAN_OUTPUT for DAST findings."
+              TEST_OUTPUT=$(make_result_json -r "SUCCESS" -t "$note")
+              echo "${TEST_OUTPUT}" | tee "$(results.TEST_OUTPUT.path)"


### PR DESCRIPTION
## Summary

- Adds a Konflux DAST pipeline for Run Once Duration Override Operator (OCP 4.21)
- Runs **RapiDAST oobtkube** (blind command injection testing via enriched CR) and **Trivy** misconfiguration scanning on an ephemeral EaaS cluster
- Config files are externalized under `configs/` for maintainability: RapiDAST config, enriched RunOnceDurationOverride CR, and RapiDAST Job spec

## Files

| File | Purpose |
| --- | --- |
| `pipelines/run-once-duration-override-operator-dast-pipeline-4-21.yaml` | Tekton Pipeline: parse-metadata, EaaS provisioning, operator install, DAST orchestration, post-process |
| `configs/rapidastconfig.yaml` | RapiDAST `generic_oobtkube` scanner config (uses `python3.12`, `POD_IP` via downward API) |
| `configs/rodoo-cr.yaml` | Enriched RunOnceDurationOverride CR with all spec fields populated for maximum oobtkube injection coverage |
| `configs/rapidast-job.yaml` | RapiDAST Job spec (runs on ephemeral cluster, writes SARIF to PVC, uploads to GCS) |

## Test plan

- [ ] Validate locally on CRC (OCP 4.21) with real Quay bundle image
- [ ] oobtkube tests all CR leaf keys, 0 command injection findings expected
- [ ] Trivy scans RODOO namespace, 0 HIGH/CRITICAL misconfigurations expected
- [ ] SARIF output produced and retrievable from PVC
- [ ] Requires `IntegrationTestScenario` in `konflux-release-data` (optional, non-blocking)
- [ ] Requires GCS secret `rapidast-sa-rodoo-key` in `rodoo-workloads-tenant` namespace