### PR TITLE
OCPBUGS-86811: Add required-scc annotations to pods,termination-message-policy,fix webhook pod image

### DIFF
--- a/deploy/07_deployment.yaml
+++ b/deploy/07_deployment.yaml
@@ -13,6 +13,8 @@ spec:
   template:
     metadata:
       name: runoncedurationoverride
+      annotations:
+        openshift.io/required-scc: restricted-v2
       labels:
         runoncedurationoverride.operator: "true"
     spec:
@@ -26,6 +28,7 @@ spec:
         emptyDir: {}
       containers:
         - name: run-once-duration-override-operator
+          terminationMessagePolicy: FallbackToLogsOnError
           securityContext:
             allowPrivilegeEscalation: false
             readOnlyRootFilesystem: true

--- a/manifests/runoncedurationoverride-operator.clusterserviceversion.yaml
+++ b/manifests/runoncedurationoverride-operator.clusterserviceversion.yaml
@@ -334,6 +334,8 @@ spec:
             template:
               metadata:
                 name: runoncedurationoverride
+                annotations:
+                  openshift.io/required-scc: restricted-v2
                 labels:
                   runoncedurationoverride.operator: "true"
               spec:

--- a/pkg/asset/daemonset.go
+++ b/pkg/asset/daemonset.go
@@ -46,6 +46,9 @@ func (d *daemonset) New() *appsv1.DaemonSet {
 			Template: corev1.PodTemplateSpec{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: d.Name(),
+					Annotations: map[string]string{
+						"openshift.io/required-scc": "hostnetwork-v2",
+					},
 					Labels: map[string]string{
 						values.SelectorLabelKey: values.SelectorLabelValue,
 						values.OwnerLabelKey:    values.OwnerLabelValue,
@@ -59,9 +62,10 @@ func (d *daemonset) New() *appsv1.DaemonSet {
 					ServiceAccountName: values.ServiceAccountName,
 					Containers: []corev1.Container{
 						{
-							Name:            d.Name(),
-							Image:           values.OperandImage,
-							ImagePullPolicy: corev1.PullAlways,
+							Name:                     d.Name(),
+							Image:                    values.OperandImage,
+							ImagePullPolicy:          corev1.PullAlways,
+							TerminationMessagePolicy: corev1.TerminationMessageFallbackToLogsOnError,
 							Command: []string{
 								"/usr/bin/run-once-duration-override",
 							},

--- a/test/e2e/bindata/assets/07_deployment.yaml
+++ b/test/e2e/bindata/assets/07_deployment.yaml
@@ -13,6 +13,8 @@ spec:
   template:
     metadata:
       name: runoncedurationoverride
+      annotations:
+        openshift.io/required-scc: restricted-v2
       labels:
         runoncedurationoverride.operator: "true"
     spec:
@@ -26,6 +28,7 @@ spec:
           type: RuntimeDefault
       containers:
         - name: run-once-duration-override-operator
+          terminationMessagePolicy: FallbackToLogsOnError
           image: RUNONCEDURATIONOVERRIDE_OPERATOR_IMAGE
           imagePullPolicy: Always
           command:

--- a/test/e2e/operator.go
+++ b/test/e2e/operator.go
@@ -148,7 +148,7 @@ func setupOperator(t testing.TB) (context.Context, context.CancelFunc, *k8sclien
 				// Set RELATED_IMAGE_OPERAND_IMAGE env
 				for i, env := range required.Spec.Template.Spec.Containers[0].Env {
 					if env.Name == "RELATED_IMAGE_OPERAND_IMAGE" {
-						required.Spec.Template.Spec.Containers[0].Env[i].Value = "registry.ci.openshift.org/ocp/4.20:run-once-duration-override-webhook"
+						required.Spec.Template.Spec.Containers[0].Env[i].Value = "quay.io/jchaloup/run-once-duration-override:4.22.0"
 						break
 					}
 				}


### PR DESCRIPTION
Hi Team,

Failure logs: 
```
https://prow.ci.openshift.org/view/gs/test-platform-results/pr-logs/pull/openshift_release/79858/rehearse-79858-pull-ci-openshift-run-once-duration-override-operator-main-e2e-aws-operator-serial-ote/2060421203251695616
```

This PR resolves the CI test failure:
```
[Monitor:required-scc-annotation-checker][sig-auth] all workloads in ns/openshift-run-once-duration-override-operator must set the 'openshift.io/required-scc' annotation
 [Monitor:termination-message-policy][sig-arch] all containers in ns/openshift-run-once-duration-override-operator must have terminationMessagePolicy=FallbackToLogsOnError 
 [sig-scheduling][Operator][Serial] RunOnceDurationOverride Operator when webhook is active should set ActiveDeadlineSeconds on pods in labeled namespaces [Suite:openshift/run-once-duration-override-operator/operator/serial]
```

PASS logs:
```
https://prow.ci.openshift.org/view/gs/test-platform-results/pr-logs/pull/openshift_run-once-duration-override-operator/1198/pull-ci-openshift-run-once-duration-override-operator-main-e2e-aws-operator-serial-ote/2063262854970085376
```