### PR TITLE
fix(.tekton): increase install-rodoo-operator timeout to 10m

### DIFF
--- a/.tekton/integration-tests/pipelines/run-once-duration-override-operator-dast-pipeline-4-21.yaml
+++ b/.tekton/integration-tests/pipelines/run-once-duration-override-operator-dast-pipeline-4-21.yaml
@@ -146,7 +146,7 @@ spec:
     # Task 4: install-rodoo-operator (from SNAPSHOT bundle via operator-sdk)
     # ──────────────────────────────────────────────────────────────────────────
     - name: install-rodoo-operator
-      timeout: "5m"
+      timeout: "10m"
       runAfter:
         - provision-cluster
       when:


### PR DESCRIPTION
## Summary

- Increases the `install-rodoo-operator` task timeout from 5m to 10m
- The 5m timeout was insufficient for `operator-sdk run bundle` to complete on ephemeral EaaS clusters, causing `TaskRunTimeout` failures

## Evidence

The DAST pipeline run `run-once-duration-override-operator-4-21-dast-m9sjq` failed at `install-rodoo-operator` after exactly 5 minutes while `operator-sdk run bundle` was still pulling and installing the bundle.