### PR TITLE
fix(.tekton): use OCP 4.21 for DAST ephemeral cluster

### DIFF
--- a/.tekton/integration-tests/pipelines/run-once-duration-override-operator-dast-pipeline-4-21.yaml
+++ b/.tekton/integration-tests/pipelines/run-once-duration-override-operator-dast-pipeline-4-21.yaml
@@ -110,7 +110,7 @@ spec:
                   value: stepactions/eaas-get-latest-openshift-version-by-prefix/0.1/eaas-get-latest-openshift-version-by-prefix.yaml
             params:
               - name: prefix
-                value: "4.20."
+                value: "4.21."
           - name: create-cluster
             ref:
               resolver: git
@@ -210,17 +210,6 @@ spec:
               echo "BUNDLE_IMAGE: ${BUNDLE_IMAGE}"
 
               oc create namespace openshift-run-once-duration-override-operator || true
-
-              echo "Waiting for ImageDigestMirrorSet to be applied on ephemeral cluster..."
-              for i in $(seq 1 30); do
-                if oc get imagedigestmirrorset -o name 2>/dev/null | grep -q .; then
-                  echo "IDMS found, waiting 30s for node config to reconcile..."
-                  sleep 30
-                  break
-                fi
-                echo "Attempt $i/30: IDMS not yet available, waiting 10s..."
-                sleep 10
-              done
 
               operator-sdk run bundle --timeout=10m \
                 --namespace openshift-run-once-duration-override-operator \

--- a/.tekton/integration-tests/pipelines/run-once-duration-override-operator-dast-pipeline-4-21.yaml
+++ b/.tekton/integration-tests/pipelines/run-once-duration-override-operator-dast-pipeline-4-21.yaml
@@ -110,7 +110,7 @@ spec:
                   value: stepactions/eaas-get-latest-openshift-version-by-prefix/0.1/eaas-get-latest-openshift-version-by-prefix.yaml
             params:
               - name: prefix
-                value: "4.20."
+                value: "4.21."
           - name: create-cluster
             ref:
               resolver: git
@@ -210,6 +210,17 @@ spec:
               echo "BUNDLE_IMAGE: ${BUNDLE_IMAGE}"
 
               oc create namespace openshift-run-once-duration-override-operator || true
+
+              echo "Waiting for ImageDigestMirrorSet to be applied on ephemeral cluster..."
+              for i in $(seq 1 30); do
+                if oc get imagedigestmirrorset -o name 2>/dev/null | grep -q .; then
+                  echo "IDMS found, waiting 30s for node config to reconcile..."
+                  sleep 30
+                  break
+                fi
+                echo "Attempt $i/30: IDMS not yet available, waiting 10s..."
+                sleep 10
+              done
 
               operator-sdk run bundle --timeout=10m \
                 --namespace openshift-run-once-duration-override-operator \

--- a/.tekton/integration-tests/pipelines/run-once-duration-override-operator-dast-pipeline-4-21.yaml
+++ b/.tekton/integration-tests/pipelines/run-once-duration-override-operator-dast-pipeline-4-21.yaml
@@ -110,7 +110,7 @@ spec:
                   value: stepactions/eaas-get-latest-openshift-version-by-prefix/0.1/eaas-get-latest-openshift-version-by-prefix.yaml
             params:
               - name: prefix
-                value: "4.21."
+                value: "4.20."
           - name: create-cluster
             ref:
               resolver: git


### PR DESCRIPTION
## Summary

- Updates the DAST pipeline ephemeral cluster version from 4.20.x to 4.21.x
- OCP 4.20 clusters fail to reconcile ImageDigestMirrorSet in time, causing operator image pulls to fail against registry.redhat.io with "manifest unknown"
- Tested and verified on Konflux EaaS with OCP 4.21 (pipeline succeeds end-to-end)