### PR TITLE
no-jira: fix(csv): add missing operatorframework.io/arch.SSS labels

### DIFF
--- a/manifests/runoncedurationoverride-operator.clusterserviceversion.yaml
+++ b/manifests/runoncedurationoverride-operator.clusterserviceversion.yaml
@@ -3,6 +3,11 @@ kind: ClusterServiceVersion
 metadata:
   name: runoncedurationoverrideoperator.v1.4.0
   namespace: run-once-duration-override-operator
+  labels:
+    operatorframework.io/arch.amd64: supported
+    operatorframework.io/arch.arm64: supported
+    operatorframework.io/arch.ppc64le: supported
+    operatorframework.io/arch.s390x: supported
   annotations:
     alm-examples: |
       [


### PR DESCRIPTION
Backporting https://github.com/openshift/run-once-duration-override-operator/pull/1105