### PR TITLE
CNTRLPLANE-3865: Add NetworkPolicy RBAC to rodo CSV

### DIFF
--- a/deploy/05_role.yaml
+++ b/deploy/05_role.yaml
@@ -69,3 +69,17 @@ rules:
       - patch
       - list
       - watch
+
+  # to have the power to manage NetworkPolicy for the operand
+  - apiGroups:
+      - networking.k8s.io
+    resources:
+      - networkpolicies
+    verbs:
+      - create
+      - delete
+      - get
+      - list
+      - patch
+      - update
+      - watch

--- a/manifests/runoncedurationoverride-operator.clusterserviceversion.yaml
+++ b/manifests/runoncedurationoverride-operator.clusterserviceversion.yaml
@@ -323,6 +323,19 @@ spec:
                 - patch
                 - list
                 - watch
+            # to have the power to manage NetworkPolicy for the operand
+            - apiGroups:
+                - networking.k8s.io
+              resources:
+                - networkpolicies
+              verbs:
+                - create
+                - delete
+                - get
+                - list
+                - patch
+                - update
+                - watch
           serviceAccountName: run-once-duration-override-operator
       deployments:
         - name: run-once-duration-override-operator

--- a/test/e2e/bindata/assets/05_role.yaml
+++ b/test/e2e/bindata/assets/05_role.yaml
@@ -69,3 +69,17 @@ rules:
       - patch
       - list
       - watch
+
+  # to have the power to manage NetworkPolicy for the operand
+  - apiGroups:
+      - networking.k8s.io
+    resources:
+      - networkpolicies
+    verbs:
+      - create
+      - delete
+      - get
+      - list
+      - patch
+      - update
+      - watch


### PR DESCRIPTION
https://redhat.atlassian.net/browse/CNTRLPLANE-3635
Create the necessary rbac for our olm based operator rodo for the control plane:

Please find the below warnings without the fix:
```
  warnings:
  - metadata:
      code: olm.required_network_policy_rbac_for_operands
      collections:
      - redhat
      - redhat_security
      description: Operators are required to manage the network policies of their
        operands. This rule verifies that operator bundles request sufficient RBAC
        permissions to manage NetworkPolicy lifecycle (create, delete, and update/patch)
        for networking.k8s.io/networkpolicies in their ClusterServiceVersion. Bundles
        whose operator name and major.minor version are listed in the `operator_network_policy_rbac_exceptions`
        rule data key are exempt from this requirement.
      effective_on: "2026-08-07T00:00:00Z"
      solution: Add a rule granting create, delete, and update/patch on networking.k8s.io/networkpolicies
        to the ClusterServiceVersion clusterPermissions or permissions, or add the
        operator name and its major.minor version to the operator_network_policy_rbac_exceptions
        rule data key.
      title: NetworkPolicy RBAC present in OLM bundle
    msg: Operator "run-once-duration-override-operator" version "1.4.1" is missing
      required NetworkPolicy RBAC (networking.k8s.io/networkpolicies with create,
      delete, and update/patch)

```
With the fix:
```
  successes:
  - metadata:
      code: olm.required_network_policy_rbac_for_operands
      collections:
      - redhat
      - redhat_security
      description: Operators are required to manage the network policies of their
        operands. This rule verifies that operator bundles request sufficient RBAC
        permissions to manage NetworkPolicy lifecycle (create, delete, and update/patch)
        for networking.k8s.io/networkpolicies in their ClusterServiceVersion. Bundles
        whose operator name and major.minor version are listed in the `operator_network_policy_rbac_exceptions`
        rule data key are exempt from this requirement.
      effective_on: "2026-08-07T00:00:00Z"
      title: NetworkPolicy RBAC present in OLM bundle
    msg: Pass
  violations: []
  warnings: []


```



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Updated installation permissions to support managing Kubernetes network policies.
  * Enables creating, viewing, updating, and deleting network policies as needed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->