### PR TITLE
CNTRLPLANE-3878: bump(k8s.io): 1.36.3)

### DIFF
--- a/.ci-operator.yaml
+++ b/.ci-operator.yaml
@@ -1,4 +1,4 @@
 build_root_image:
   name: release
   namespace: openshift
-  tag: rhel-9-release-golang-1.25-openshift-4.22
+  tag: rhel-9-release-golang-1.26-openshift-5.0

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM brew.registry.redhat.io/rh-osbs/openshift-golang-builder:rhel_9_1.25 as builder
+FROM brew.registry.redhat.io/rh-osbs/openshift-golang-builder:rhel_9_golang_1.26 as builder
 WORKDIR /go/src/github.com/openshift/run-once-duration-override-operator
 COPY . .
 RUN make build --warn-undefined-variables
@@ -13,9 +13,9 @@ LABEL io.k8s.display-name="Run Once Duration Override Operator based on RHEL 9" 
       distribution-scope="public" \
       com.redhat.component="run-once-duration-override-operator-container" \
       name="run-once-duration-override-operator/run-once-duration-override-rhel9-operator" \
-      cpe="cpe:/a:redhat:run_once_duration_override_operator:1.4::el9" \
-      release="1.4.1" \
-      version="1.4.1" \
+      cpe="cpe:/a:redhat:run_once_duration_override_operator:1.5::el9" \
+      release="1.5.0" \
+      version="1.5.0" \
       url="https://github.com/openshift/run-once-duration-override-operator" \
       vendor="Red Hat, Inc." \
       summary="run-once-duration-override-operator" \

--- a/Dockerfile.metadata
+++ b/Dockerfile.metadata
@@ -1,8 +1,8 @@
-FROM registry.ci.openshift.org/ocp/builder:rhel-9-golang-1.25-openshift-4.22 AS builder
+FROM registry.ci.openshift.org/ocp/builder:rhel-9-golang-1.26-openshift-5.0 AS builder
 WORKDIR /go/src/github.com/openshift/run-once-duration-override-operator
 COPY . .
 
-FROM registry.ci.openshift.org/ocp/4.22:base-rhel9
+FROM registry.ci.openshift.org/ocp/5.0:base-rhel9
 COPY --from=builder /go/src/github.com/openshift/run-once-duration-override-operator/manifests /manifests
 COPY --from=builder /go/src/github.com/openshift/run-once-duration-override-operator/metadata /metadata
 

--- a/Dockerfile.rhel7
+++ b/Dockerfile.rhel7
@@ -1,11 +1,11 @@
-FROM registry.ci.openshift.org/ocp/builder:rhel-9-golang-1.25-openshift-4.22 AS builder
+FROM registry.ci.openshift.org/ocp/builder:rhel-9-golang-1.26-openshift-5.0 AS builder
 WORKDIR /go/src/github.com/openshift/run-once-duration-override-operator
 COPY . .
 
 RUN make build --warn-undefined-variables \
     && gzip run-once-duration-override-operator-tests-ext
 
-FROM registry.ci.openshift.org/ocp/4.22:base-rhel9
+FROM registry.ci.openshift.org/ocp/5.0:base-rhel9
 COPY --from=builder /go/src/github.com/openshift/run-once-duration-override-operator/run-once-duration-override-operator /usr/bin/
 COPY --from=builder /go/src/github.com/openshift/run-once-duration-override-operator/run-once-duration-override-operator-tests-ext.gz /usr/bin/
 # Upstream bundle and index images does not support versioning so
@@ -16,8 +16,8 @@ LABEL io.k8s.display-name="OpenShift Run Once Duration Override Operator" \
       io.k8s.description="Manages Run Once Duration Override mutating admission webhook" \
       io.openshift.tags="openshift,mutating-admission,run-once" \
       com.redhat.delivery.appregistry=true \
-      release="1.4.1" \
-      version="1.4.1" \
+      release="1.5.0" \
+      version="1.5.0" \
       url="https://github.com/openshift/run-once-duration-override-operator" \
       vendor="Red Hat, Inc." \
       maintainer="AOS workloads team, <aos-workloads@redhat.com>"

--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ This operator manages OpenShift `RunOnceDurationOverride` Admission Webhook Serv
 | 1.3.1         | 4.19, 4.20  | 1.33        | 1.24   |
 | 1.4.0         | 4.21, 4.22  | 1.34        | 1.24   |
 | 1.4.1         | 4.21, 4.22  | 1.35        | 1.25   |
+| 1.5.0         | 4.23, 4.24  | 1.36        | 1.26   |
 
 ## Deploy the Operator
 

--- a/bundle.Dockerfile
+++ b/bundle.Dockerfile
@@ -1,4 +1,4 @@
-FROM brew.registry.redhat.io/rh-osbs/openshift-golang-builder:rhel_9_1.25 as builder
+FROM brew.registry.redhat.io/rh-osbs/openshift-golang-builder:rhel_9_golang_1.26 as builder
 WORKDIR /go/src/github.com/openshift/run-once-duration-override-operator
 COPY . .
 
@@ -41,9 +41,9 @@ LABEL com.redhat.component="run-once-duration-override-operator-bundle-container
 LABEL description="Run Once Duration Override mutating admission webhook support for OpenShift based on RHEL 9"
 LABEL distribution-scope="public"
 LABEL name="run-once-duration-override-operator/run-once-duration-override-operator-bundle"
-LABEL cpe="cpe:/a:redhat:run_once_duration_override_operator:1.4::el9"
-LABEL release="1.4.1"
-LABEL version="1.4.1"
+LABEL cpe="cpe:/a:redhat:run_once_duration_override_operator:1.5::el9"
+LABEL release="1.5.0"
+LABEL version="1.5.0"
 LABEL url="https://github.com/openshift/run-once-duration-override-operator"
 LABEL vendor="Red Hat, Inc."
 LABEL summary="Run Once Duration Override mutating admission webhook support for OpenShift"
@@ -52,7 +52,7 @@ LABEL io.k8s.display-name="run-once-duration-override-operator based on RHEL 9"
 LABEL io.k8s.description="Run Once Duration Override mutating admission webhook support for OpenShift based on RHEL 9"
 LABEL io.openshift.tags="openshift,run-once-duration-override-operator"
 LABEL com.redhat.delivery.operator.bundle=true
-LABEL com.redhat.openshift.versions="v4.19"
+LABEL com.redhat.openshift.versions="v4.23"
 LABEL com.redhat.delivery.appregistry=true
 LABEL maintainer="AOS workloads team, <aos-workloads-staff@redhat.com>"
 

--- a/manifests/runoncedurationoverride-operator.clusterserviceversion.yaml
+++ b/manifests/runoncedurationoverride-operator.clusterserviceversion.yaml
@@ -1,7 +1,7 @@
 apiVersion: operators.coreos.com/v1alpha1
 kind: ClusterServiceVersion
 metadata:
-  name: runoncedurationoverrideoperator.v1.4.1
+  name: runoncedurationoverrideoperator.v1.5.0
   namespace: openshift-run-once-duration-override-operator
   labels:
     operatorframework.io/arch.amd64: supported
@@ -29,7 +29,7 @@ metadata:
       ]
     certifiedLevel: "false"
     containerImage: registry-proxy.engineering.redhat.com/rh-osbs/run-once-duration-override-rhel9-operator:latest
-    createdAt: "2026-04-23"
+    createdAt: "2026-08-16"
     features.operators.openshift.io/disconnected: "true"
     features.operators.openshift.io/fips-compliant: "true"
     features.operators.openshift.io/proxy-aware: "false"
@@ -40,7 +40,7 @@ metadata:
     features.operators.openshift.io/cnf: "false"
     features.operators.openshift.io/cni: "false"
     features.operators.openshift.io/csi: "false"
-    olm.skipRange: ">=1.3.0 <1.4.1"
+    olm.skipRange: ">=1.4.0 <1.5.0"
     description: An operator to manage the OpenShift RunOnceDurationOverride Mutating Admission Webhook Server
     repository: https://github.com/openshift/run-once-duration-override-operator
     support: Red Hat, Inc.
@@ -49,18 +49,11 @@ metadata:
     operators.openshift.io/valid-subscription: '["OpenShift Container Platform", "OpenShift Platform Plus"]'
     operatorframework.io/suggested-namespace: "openshift-run-once-duration-override-operator"
 spec:
-  replaces: runoncedurationoverrideoperator.v1.3.0
+  replaces: runoncedurationoverrideoperator.v1.4.0
   # buffering up to 6 1.1.z releases to allow to include these in all supported bundle index images
   # The buffer len 6 should be sufficient for normal cadance. Including CVE releases.
   # The buffer can be extened later as needed.
   skips:
-    - runoncedurationoverrideoperator.v1.2.0
-    - runoncedurationoverrideoperator.v1.2.1
-    - runoncedurationoverrideoperator.v1.2.2
-    - runoncedurationoverrideoperator.v1.2.3
-    - runoncedurationoverrideoperator.v1.2.4
-    - runoncedurationoverrideoperator.v1.2.5
-    - runoncedurationoverrideoperator.v1.2.6
     - runoncedurationoverrideoperator.v1.3.0
     - runoncedurationoverrideoperator.v1.3.1
     - runoncedurationoverrideoperator.v1.3.2
@@ -69,6 +62,12 @@ spec:
     - runoncedurationoverrideoperator.v1.3.5
     - runoncedurationoverrideoperator.v1.3.6
     - runoncedurationoverrideoperator.v1.4.0
+    - runoncedurationoverrideoperator.v1.4.1
+    - runoncedurationoverrideoperator.v1.4.2
+    - runoncedurationoverrideoperator.v1.4.3
+    - runoncedurationoverrideoperator.v1.4.4
+    - runoncedurationoverrideoperator.v1.4.5
+    - runoncedurationoverrideoperator.v1.4.6
   customresourcedefinitions:
     owned:
       - displayName: Run Once Duration Override
@@ -83,7 +82,7 @@ spec:
   provider:
     name: Red Hat, Inc.
   maturity: beta
-  version: 1.4.1
+  version: 1.5.0
   relatedImages:
     - name: run-once-duration-override-operand
       image: registry-proxy.engineering.redhat.com/rh-osbs/run-once-duration-override-rhel-9:latest
@@ -97,10 +96,10 @@ spec:
   maintainers:
     - email: support@redhat.com
       name: Red Hat
-  minKubeVersion: 1.34.0
+  minKubeVersion: 1.36.0
   labels:
     olm-owner-enterprise-app: run-once-duration-override-operator
-    olm-status-descriptors: run-once-duration-override-operator.v1.4.1
+    olm-status-descriptors: run-once-duration-override-operator.v1.5.0
   installModes:
     - supported: true
       type: OwnNamespace
@@ -384,7 +383,7 @@ spec:
                       - name: RELATED_IMAGE_OPERAND_IMAGE
                         value: registry-proxy.engineering.redhat.com/rh-osbs/run-once-duration-override-rhel-9:latest
                       - name: OPERAND_VERSION
-                        value: 1.4.1
+                        value: 1.5.0
                     ports:
                       - containerPort: 8080
                     readinessProbe:


### PR DESCRIPTION
ssia

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for release 1.5.0 with Go 1.26 and Kubernetes 1.36.
  * Updated compatibility information for OpenShift 4.23–4.24.

* **Updates**
  * Upgraded build and runtime environments to newer OpenShift 5.0 and RHEL 9 images.
  * Updated product, bundle, and release metadata to version 1.5.0.
  * Refined upgrade paths for the 1.4.x release series.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->